### PR TITLE
Replace sign out text button with icon-only button on mobile

### DIFF
--- a/app/mentor/_components/signout-button.tsx
+++ b/app/mentor/_components/signout-button.tsx
@@ -2,7 +2,9 @@
 
 import { useAuthActions } from '@convex-dev/auth/react'
 import { Authenticated } from 'convex/react'
+import { LogOut } from 'lucide-react'
 import posthog from 'posthog-js'
+import { Button } from '@/components/ui/button'
 
 export function SignOutButton() {
 	const { signOut } = useAuthActions()
@@ -16,12 +18,15 @@ export function SignOutButton() {
 
 	return (
 		<Authenticated>
-			<button
-				className="bg-slate-200 dark:bg-slate-800 text-foreground rounded-full px-3 py-1 text-sm"
+			<Button
+				variant="ghost"
+				size="icon"
+				aria-label="Sign out"
+				className="text-gray-600 hover:text-brand"
 				onClick={handleSignOut}
 			>
-				Sign out
-			</button>
+				<LogOut className="h-6 w-6" />
+			</Button>
 		</Authenticated>
 	)
 }


### PR DESCRIPTION
Matches the ghost icon-button style used by HomeButton and HelpPopover in the navbar.

https://claude.ai/code/session_01USo67cvYhoZb9B4ZcM1Bxr