### PR TITLE
✨ Add canvas section for visual/gestalt learners

### DIFF
--- a/app/learner/[passphrase]/canvas/_components/canvas-page-client.tsx
+++ b/app/learner/[passphrase]/canvas/_components/canvas-page-client.tsx
@@ -1,8 +1,8 @@
 'use client'
 
-import { useQuery, useMutation } from 'convex/react'
+import { usePreloadedQuery, useQuery, useMutation } from 'convex/react'
 import { api } from '@/convex/_generated/api'
-import { useState, use } from 'react'
+import { useState } from 'react'
 import {
 	CanvasEmptyState,
 	CanvasCarousel,
@@ -10,23 +10,20 @@ import {
 } from '@/components/canvas'
 import type { Canvas, CanvasBlock } from '@/lib/types/canvas'
 import { Id } from '@/convex/_generated/dataModel'
+import { Preloaded } from 'convex/react'
 
-export default function LearnerCanvasPage({
-	params,
+export default function CanvasPageClient({
+	passphrase,
+	preloadedLearner,
 }: {
-	params: Promise<{ passphrase: string }>
+	passphrase: string
+	preloadedLearner: Preloaded<typeof api.learners.getByPassphrase>
 }) {
-	const resolvedParams = use(params)
-	const passphrase = resolvedParams.passphrase
-
-	const learner = useQuery(
-		api.learners.getByPassphrase,
-		passphrase ? { passphrase } : 'skip',
-	)
+	const learner = usePreloadedQuery(preloadedLearner)
 
 	const convexCanvases = useQuery(
-		api.canvas.getCanvasesByPassphrase,
-		passphrase ? { passphrase } : 'skip',
+		api.canvas.getCanvases,
+		learner?._id ? { learnerId: learner._id } : 'skip',
 	)
 
 	const [selectedCanvasId, setSelectedCanvasId] = useState<string | undefined>(
@@ -37,6 +34,14 @@ export default function LearnerCanvasPage({
 	const createCanvasMutation = useMutation(api.canvas.createCanvas)
 	const updateCanvasMutation = useMutation(api.canvas.updateCanvas)
 	const deleteCanvasMutation = useMutation(api.canvas.deleteCanvas)
+
+	if (!learner) {
+		return (
+			<div className="container mx-auto p-4 max-w-4xl text-center text-gray-500 py-12">
+				Learner not found.
+			</div>
+		)
+	}
 
 	const canvases: Canvas[] = (convexCanvases || []).map(c => ({
 		id: c._id,
@@ -63,7 +68,8 @@ export default function LearnerCanvasPage({
 		title: string
 		blocks: CanvasBlock[]
 	}) => {
-		const learnerId = learner?._id
+		if (!learner?._id) return
+
 		if (selectedCanvasId && !isCreating) {
 			await updateCanvasMutation({
 				canvasId: selectedCanvasId as Id<'canvases'>,
@@ -72,7 +78,7 @@ export default function LearnerCanvasPage({
 			})
 		} else {
 			const newId = await createCanvasMutation({
-				learnerId: learnerId,
+				learnerId: learner._id,
 				title: data.title,
 				blocks: data.blocks,
 			})

--- a/app/mentor/learner/[id]/activities/page.tsx
+++ b/app/mentor/learner/[id]/activities/page.tsx
@@ -11,8 +11,6 @@ import { useState } from 'react'
 import { toast } from 'sonner'
 import { MentorActivityCardDisplay } from './mentor-activity-card-display'
 
-export { MentorActivityCardDisplay } from './mentor-activity-card-display'
-
 interface Activity {
 	id: string
 	boardId: Id<'boards'>

--- a/bun.lock
+++ b/bun.lock
@@ -74,6 +74,8 @@
         "zod": "^3.24.1",
       },
       "devDependencies": {
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/react": "^16.3.2",
         "@types/bun": "^1.3.8",
         "@types/canvas-confetti": "^1.6.4",
         "@types/events": "^3.0.3",
@@ -86,6 +88,7 @@
         "dotenv": "^16.4.7",
         "eslint": "^9.33.0",
         "eslint-config-next": "15.5.12",
+        "happy-dom": "^20.11.1",
         "husky": "^9.1.7",
         "msw": "^2.12.9",
         "npm-run-all": "^4.1.5",
@@ -108,6 +111,10 @@
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
 
     "@auth/core": ["@auth/core@0.37.4", "", { "dependencies": { "@panva/hkdf": "^1.2.1", "jose": "^5.9.6", "oauth4webapi": "^3.1.1", "preact": "10.24.3", "preact-render-to-string": "6.5.11" }, "peerDependencies": { "@simplewebauthn/browser": "^9.0.1", "@simplewebauthn/server": "^9.0.2", "nodemailer": "^6.8.0" }, "optionalPeers": ["@simplewebauthn/browser", "@simplewebauthn/server", "nodemailer"] }, "sha512-HOXJwXWXQRhbBDHlMU0K/6FT1v+wjtzdKhsNg0ZN7/gne6XPsIrjZ4daMcFnbq0Z/vsAbYBinQhhua0d77v7qw=="],
+
+    "@babel/code-frame": ["@babel/code-frame@7.29.7", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.29.7", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw=="],
+
+    "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
 
     "@babel/runtime": ["@babel/runtime@7.28.6", "", {}, "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA=="],
 
@@ -669,6 +676,10 @@
 
     "@swc/helpers": ["@swc/helpers@0.5.15", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g=="],
 
+    "@testing-library/dom": ["@testing-library/dom@10.4.1", "", { "dependencies": { "@babel/code-frame": "^7.10.4", "@babel/runtime": "^7.12.5", "@types/aria-query": "^5.0.1", "aria-query": "5.3.0", "dom-accessibility-api": "^0.5.9", "lz-string": "^1.5.0", "picocolors": "1.1.1", "pretty-format": "^27.0.2" } }, "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg=="],
+
+    "@testing-library/react": ["@testing-library/react@16.3.2", "", { "dependencies": { "@babel/runtime": "^7.12.5" }, "peerDependencies": { "@testing-library/dom": "^10.0.0", "@types/react": "^18.0.0 || ^19.0.0", "@types/react-dom": "^18.0.0 || ^19.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g=="],
+
     "@tinyhttp/accepts": ["@tinyhttp/accepts@1.3.0", "", { "dependencies": { "es-mime-types": "^0.0.16", "negotiator": "^0.6.2" } }, "sha512-YaJ4EMgVUI6JHzWO14lr6vn/BLJEoFN4Sqd20l0/oBcLLENkP8gnPtX1jB7OhIu0AE40VCweAqvSP+0/pgzB1g=="],
 
     "@tinyhttp/app": ["@tinyhttp/app@1.3.0", "", { "dependencies": { "@tinyhttp/cookie": "1.3.0", "@tinyhttp/proxy-addr": "1.3.0", "@tinyhttp/req": "1.3.0", "@tinyhttp/res": "1.3.0", "@tinyhttp/router": "1.3.0", "regexparam": "^1.3.0" } }, "sha512-EPqdanEZ/vhpuxl4Nn/QIkS+5Wkbt8NgO/FqYj2kHttvwYkaoSFi7HUns17UQAQcak5JLbPEt67Qf4wvwy/fNQ=="],
@@ -706,6 +717,8 @@
     "@ts-morph/common": ["@ts-morph/common@0.11.1", "", { "dependencies": { "fast-glob": "^3.2.7", "minimatch": "^3.0.4", "mkdirp": "^1.0.4", "path-browserify": "^1.0.1" } }, "sha512-7hWZS0NRpEsNV8vWJzg7FEz6V8MaLNeJOmwmghqUXTpzk16V1LLZhdo+4QvE/+zv4cVci0OviuJFnqhEfoV3+g=="],
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.8.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-Z96T/L6dUFFxgFJ+pQtkPpne9q7i6kIPYCFnQBHSgSPV9idTsKfIhCss0h5iM9irweZCatkrdeP8yi5uM1eX6Q=="],
+
+    "@types/aria-query": ["@types/aria-query@5.0.4", "", {}, "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw=="],
 
     "@types/bun": ["@types/bun@1.3.8", "", { "dependencies": { "bun-types": "1.3.8" } }, "sha512-3LvWJ2q5GerAXYxO2mffLTqOzEu5qnhEAlh48Vnu8WQfnmSwbgagjGZV6BoHKJztENYEDn6QmVd949W4uESRJA=="],
 
@@ -752,6 +765,10 @@
     "@types/statuses": ["@types/statuses@2.0.6", "", {}, "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA=="],
 
     "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
+
+    "@types/whatwg-mimetype": ["@types/whatwg-mimetype@3.0.2", "", {}, "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA=="],
+
+    "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
 
     "@types/yauzl": ["@types/yauzl@2.10.3", "", { "dependencies": { "@types/node": "*" } }, "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q=="],
 
@@ -917,7 +934,7 @@
 
     "aria-hidden": ["aria-hidden@1.2.6", "", { "dependencies": { "tslib": "^2.0.0" } }, "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA=="],
 
-    "aria-query": ["aria-query@5.3.2", "", {}, "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw=="],
+    "aria-query": ["aria-query@5.3.0", "", { "dependencies": { "dequal": "^2.0.3" } }, "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A=="],
 
     "array-buffer-byte-length": ["array-buffer-byte-length@1.0.2", "", { "dependencies": { "call-bound": "^1.0.3", "is-array-buffer": "^3.0.5" } }, "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw=="],
 
@@ -1000,6 +1017,8 @@
     "buffer": ["buffer@5.7.1", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.1.13" } }, "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ=="],
 
     "buffer-crc32": ["buffer-crc32@0.2.13", "", {}, "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ=="],
+
+    "buffer-image-size": ["buffer-image-size@0.6.4", "", { "dependencies": { "@types/node": "*" } }, "sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ=="],
 
     "bun-types": ["bun-types@1.3.8", "", { "dependencies": { "@types/node": "*" } }, "sha512-fL99nxdOWvV4LqjmC+8Q9kW3M4QTtTR1eePs94v5ctGqU8OeceWrSUaRw3JYb7tU3FkMIAjkueehrHPPPGKi5Q=="],
 
@@ -1163,6 +1182,8 @@
 
     "depd": ["depd@1.1.2", "", {}, "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ=="],
 
+    "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
+
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
     "detect-node-es": ["detect-node-es@1.1.0", "", {}, "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="],
@@ -1172,6 +1193,8 @@
     "dlv": ["dlv@1.1.3", "", {}, "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA=="],
 
     "doctrine": ["doctrine@2.1.0", "", { "dependencies": { "esutils": "^2.0.2" } }, "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw=="],
+
+    "dom-accessibility-api": ["dom-accessibility-api@0.5.16", "", {}, "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="],
 
     "dom-helpers": ["dom-helpers@5.2.1", "", { "dependencies": { "@babel/runtime": "^7.8.7", "csstype": "^3.0.2" } }, "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA=="],
 
@@ -1209,7 +1232,7 @@
 
     "enquirer": ["enquirer@2.4.1", "", { "dependencies": { "ansi-colors": "^4.1.1", "strip-ansi": "^6.0.1" } }, "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ=="],
 
-    "entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
+    "entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
 
     "error-ex": ["error-ex@1.3.4", "", { "dependencies": { "is-arrayish": "^0.2.1" } }, "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ=="],
 
@@ -1410,6 +1433,8 @@
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 
     "graphql": ["graphql@16.12.0", "", {}, "sha512-DKKrynuQRne0PNpEbzuEdHlYOMksHSUI8Zc9Unei5gTsMNA2/vMpoMz/yKba50pejK56qj98qM0SjYxAKi13gQ=="],
+
+    "happy-dom": ["happy-dom@20.11.1", "", { "dependencies": { "@types/node": ">=20.0.0", "@types/whatwg-mimetype": "^3.0.2", "@types/ws": "^8.18.1", "buffer-image-size": "^0.6.4", "entities": "^7.0.1", "whatwg-mimetype": "^3.0.0", "ws": "^8.21.0" } }, "sha512-XSt8tMzbW9ymE7687xztkO1ckR7qJNQ3LywY9vlYGhGi3zXrGBHuUo2Cl1ztZaICW+1eAGdkLbj6iwVqDT33kg=="],
 
     "has-bigints": ["has-bigints@1.1.0", "", {}, "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg=="],
 
@@ -1639,6 +1664,8 @@
 
     "luxon": ["luxon@3.7.2", "", {}, "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew=="],
 
+    "lz-string": ["lz-string@1.5.0", "", { "bin": { "lz-string": "bin/bin.js" } }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
+
     "map-stream": ["map-stream@0.1.0", "", {}, "sha512-CkYQrPYZfWnu/DAmVCpTSX/xHpKZ80eKh2lAkyA6AJTef6bW+6JpbQZN5rofum7da+SyN1bi5ctTm+lTfcCW3g=="],
 
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
@@ -1840,6 +1867,8 @@
     "prettier": ["prettier@3.8.1", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg=="],
 
     "pretty-bytes": ["pretty-bytes@5.6.0", "", {}, "sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg=="],
+
+    "pretty-format": ["pretty-format@27.5.1", "", { "dependencies": { "ansi-regex": "^5.0.1", "ansi-styles": "^5.0.0", "react-is": "^17.0.1" } }, "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ=="],
 
     "pretty-ms": ["pretty-ms@7.0.1", "", { "dependencies": { "parse-ms": "^2.1.0" } }, "sha512-973driJZvxiGOQ5ONsFhOF/DtzPMOMtgC11kCpUrPGMTgqp2q/1gwzCquocrN33is0VZ5GFHXZYMM9l6h67v2Q=="],
 
@@ -2195,6 +2224,8 @@
 
     "webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
 
+    "whatwg-mimetype": ["whatwg-mimetype@3.0.0", "", {}, "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q=="],
+
     "whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
@@ -2213,7 +2244,7 @@
 
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
-    "ws": ["ws@8.19.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg=="],
+    "ws": ["ws@8.21.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw=="],
 
     "xdg-app-paths": ["xdg-app-paths@5.1.0", "", { "dependencies": { "xdg-portable": "^7.0.0" } }, "sha512-RAQ3WkPf4KTU1A8RtFx3gWywzVKe00tfOPFfl2NDGqbIFENQO4kqAJp7mhQjNj/33W5x5hiWWUdyfPq/5SU3QA=="],
 
@@ -2246,6 +2277,8 @@
     "@cypress/request/tough-cookie": ["tough-cookie@5.1.2", "", { "dependencies": { "tldts": "^6.1.32" } }, "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A=="],
 
     "@cypress/xvfb/debug": ["debug@3.2.7", "", { "dependencies": { "ms": "^2.1.1" } }, "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ=="],
+
+    "@elevenlabs/elevenlabs-js/ws": ["ws@8.19.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg=="],
 
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 
@@ -2481,6 +2514,8 @@
 
     "cmdk/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
 
+    "dom-serializer/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
+
     "edge-runtime/async-listen": ["async-listen@3.0.1", "", {}, "sha512-cWMaNwUJnf37C/S5TfCkk/15MwbPRwVYALA2jtjkbHjCmAPiDXyNJy2q3p1KAZzDLHAWyarUWSujUoHR4pEgrA=="],
 
     "edge-runtime/picocolors": ["picocolors@1.0.0", "", {}, "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="],
@@ -2499,6 +2534,8 @@
 
     "eslint-plugin-import/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
+    "eslint-plugin-jsx-a11y/aria-query": ["aria-query@5.3.2", "", {}, "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw=="],
+
     "eslint-plugin-react/resolve": ["resolve@2.0.0-next.5", "", { "dependencies": { "is-core-module": "^2.13.0", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA=="],
 
     "eslint-plugin-react/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
@@ -2510,6 +2547,8 @@
     "glob/minimatch": ["minimatch@10.2.4", "", { "dependencies": { "brace-expansion": "^5.0.2" } }, "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg=="],
 
     "hasha/type-fest": ["type-fest@0.8.1", "", {}, "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA=="],
+
+    "htmlparser2/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
 
     "http-errors/inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
 
@@ -2538,6 +2577,10 @@
     "path-type/pify": ["pify@3.0.0", "", {}, "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg=="],
 
     "posthog-js/preact": ["preact@10.28.3", "", {}, "sha512-tCmoRkPQLpBeWzpmbhryairGnhW9tKV6c6gr/w+RhoRoKEJwsjzipwp//1oCpGPOchvSLaAPlpcJi9MwMmoPyA=="],
+
+    "pretty-format/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
+
+    "pretty-format/react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
 
     "prop-types/react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
 

--- a/components/canvas.test.tsx
+++ b/components/canvas.test.tsx
@@ -1,0 +1,433 @@
+import { GlobalWindow } from 'happy-dom'
+
+const windowInstance = new GlobalWindow()
+Object.assign(globalThis, {
+	window: windowInstance,
+	document: windowInstance.document,
+	navigator: windowInstance.navigator,
+	HTMLElement: windowInstance.HTMLElement,
+	Element: windowInstance.Element,
+	Node: windowInstance.Node,
+	CustomEvent: windowInstance.CustomEvent,
+	HTMLInputElement: windowInstance.HTMLInputElement,
+	HTMLButtonElement: windowInstance.HTMLButtonElement,
+})
+import { describe, it, expect, mock, beforeEach } from 'bun:test'
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+import type {
+	Canvas,
+	CanvasBlock,
+	CanvasBlockType,
+	CanvasEmptyStateProps,
+	CanvasExamplePreviewProps,
+	CanvasCarouselProps,
+	CanvasCardProps,
+	CanvasBlockItemProps,
+	CanvasEditorProps,
+	CanvasDeleteConfirmationModalProps,
+	CanvasCreatedEventPayload,
+	CanvasBlockTappedEventPayload,
+	CanvasDeletedEventPayload,
+} from '@/lib/types/canvas'
+import {
+	CanvasEmptyState,
+	CanvasExamplePreview,
+	CanvasCarousel,
+	CanvasCard,
+	CanvasBlockItem,
+	CanvasEditor,
+	CanvasDeleteConfirmationModal,
+} from './canvas'
+
+// Mock posthog on window object
+declare global {
+	interface Window {
+		posthog?: {
+			capture: (event: string, properties?: Record<string, any>) => void
+		}
+	}
+}
+
+const mockPosthogCapture = mock()
+
+beforeEach(() => {
+	cleanup()
+	mockPosthogCapture.mockReset()
+	window.posthog = {
+		capture: mockPosthogCapture,
+	}
+})
+
+describe('Canvas Components Unit Tests', () => {
+	describe('CanvasEmptyState Component', () => {
+		it('renders canvas-empty-state, canvas-example-preview, and create-canvas-button', () => {
+			const handleCreate = mock()
+			render(<CanvasEmptyState onCreateCanvas={handleCreate} />)
+
+			const emptyState = document.querySelector(
+				'[data-name="canvas-empty-state"]'
+			)
+			const examplePreview = document.querySelector(
+				'[data-name="canvas-example-preview"]'
+			)
+			const createBtn = document.querySelector(
+				'[data-name="create-canvas-button"]'
+			)
+
+			expect(emptyState).not.toBeNull()
+			expect(examplePreview).not.toBeNull()
+			expect(createBtn).not.toBeNull()
+		})
+
+		it('triggers onCreateCanvas callback when create-canvas-button is clicked', () => {
+			const handleCreate = mock()
+			render(<CanvasEmptyState onCreateCanvas={handleCreate} />)
+
+			const createBtn = document.querySelector(
+				'[data-name="create-canvas-button"]'
+			)
+			expect(createBtn).not.toBeNull()
+			if (createBtn) {
+				fireEvent.click(createBtn)
+				expect(handleCreate).toHaveBeenCalledTimes(1)
+			}
+		})
+	})
+
+	describe('CanvasExamplePreview Component', () => {
+		it('renders visual canvas example preview container with data-name="canvas-example-preview"', () => {
+			const sampleBlocks: CanvasBlock[] = [
+				{
+					id: 'b1',
+					type: 'emoji',
+					content: '🎨',
+					phrase: 'Paint brush',
+					seed: 'paint-seed',
+				},
+				{
+					id: 'b2',
+					type: 'letter',
+					content: 'A',
+					phrase: 'Letter A',
+					seed: 'letter-a-seed',
+				},
+			]
+			render(<CanvasExamplePreview blocks={sampleBlocks} />)
+
+			const preview = document.querySelector(
+				'[data-name="canvas-example-preview"]'
+			)
+			expect(preview).not.toBeNull()
+		})
+	})
+
+	describe('CanvasEditor Component - Canvas Creation & Block Adding', () => {
+		const blockTypes: CanvasBlockType[] = [
+			'script',
+			'activity',
+			'emoji',
+			'letter',
+			'number',
+			'paint',
+		]
+
+		it('renders canvas-title-input, save-canvas-button, and add-block buttons for all block types', () => {
+			const handleSave = mock()
+			render(<CanvasEditor onSave={handleSave} />)
+
+			const titleInput = document.querySelector(
+				'[data-name="canvas-title-input"]'
+			)
+			const saveBtn = document.querySelector(
+				'[data-name="save-canvas-button"]'
+			)
+
+			expect(titleInput).not.toBeNull()
+			expect(saveBtn).not.toBeNull()
+
+			blockTypes.forEach(type => {
+				const addBtn = document.querySelector(
+					`[data-name="add-block-${type}"]`
+				)
+				expect(addBtn).not.toBeNull()
+			})
+		})
+
+		it('allows typing a title, adding blocks for each type (script, activity, emoji, letter, number, paint), saving canvas, and triggers posthog event "canvas_created"', () => {
+			const handleSave = mock()
+			render(<CanvasEditor onSave={handleSave} />)
+
+			const titleInput = document.querySelector(
+				'[data-name="canvas-title-input"]'
+			) as HTMLInputElement
+			expect(titleInput).not.toBeNull()
+			fireEvent.change(titleInput, { target: { value: 'My Creative Space' } })
+
+			blockTypes.forEach(type => {
+				const addBtn = document.querySelector(
+					`[data-name="add-block-${type}"]`
+				)
+				expect(addBtn).not.toBeNull()
+				if (addBtn) {
+					fireEvent.click(addBtn)
+				}
+				const blockItem = document.querySelector(
+					`[data-name="canvas-block-${type}"]`
+				)
+				expect(blockItem).not.toBeNull()
+			})
+
+			const saveBtn = document.querySelector(
+				'[data-name="save-canvas-button"]'
+			)
+			expect(saveBtn).not.toBeNull()
+			if (saveBtn) {
+				fireEvent.click(saveBtn)
+			}
+
+			expect(handleSave).toHaveBeenCalledTimes(1)
+			expect(handleSave).toHaveBeenCalledWith({
+				title: 'My Creative Space',
+				blocks: expect.arrayContaining(
+					blockTypes.map(type => expect.objectContaining({ type }))
+				),
+			})
+
+			expect(mockPosthogCapture).toHaveBeenCalledWith(
+				'canvas_created',
+				expect.objectContaining({
+					title: 'My Creative Space',
+					blockTypes: expect.arrayContaining(blockTypes),
+				} as CanvasCreatedEventPayload)
+			)
+		})
+	})
+
+	describe('CanvasBlockItem Component - View, Speech Output & Seed Bounce Animation', () => {
+		const sampleBlock: CanvasBlock = {
+			id: 'block-1',
+			type: 'emoji',
+			content: '⭐',
+			label: 'Star',
+			phrase: 'Shining star',
+			seed: 'Shining star',
+		}
+
+		it('renders block element with data-name="canvas-block-${blockType}"', () => {
+			render(<CanvasBlockItem block={sampleBlock} />)
+
+			const blockEl = document.querySelector(
+				`[data-name="canvas-block-${sampleBlock.type}"]`
+			)
+			expect(blockEl).not.toBeNull()
+		})
+
+		it('applies animate-seed-bounce CSS class when tapped or when isAnimating is true', () => {
+			const handleTap = mock()
+			const { rerender } = render(
+				<CanvasBlockItem block={sampleBlock} onTap={handleTap} />
+			)
+
+			const blockEl = document.querySelector(
+				`[data-name="canvas-block-${sampleBlock.type}"]`
+			)
+			expect(blockEl).not.toBeNull()
+
+			if (blockEl) {
+				fireEvent.click(blockEl)
+				expect(handleTap).toHaveBeenCalledWith(sampleBlock)
+			}
+
+			rerender(
+				<CanvasBlockItem
+					block={sampleBlock}
+					onTap={handleTap}
+					isAnimating={true}
+				/>
+			)
+			const animatingBlockEl = document.querySelector(
+				`[data-name="canvas-block-${sampleBlock.type}"]`
+			)
+			expect(
+				animatingBlockEl?.classList.contains('animate-seed-bounce')
+			).toBe(true)
+		})
+
+		it('triggers say out loud speech output and posthog event "canvas_block_tapped" on tap', () => {
+			const handleTap = mock()
+			render(<CanvasBlockItem block={sampleBlock} onTap={handleTap} />)
+
+			const blockEl = document.querySelector(
+				`[data-name="canvas-block-${sampleBlock.type}"]`
+			)
+			expect(blockEl).not.toBeNull()
+
+			if (blockEl) {
+				fireEvent.click(blockEl)
+				expect(handleTap).toHaveBeenCalledWith(sampleBlock)
+			}
+
+			expect(mockPosthogCapture).toHaveBeenCalledWith(
+				'canvas_block_tapped',
+				expect.objectContaining({
+					blockType: sampleBlock.type,
+					content: sampleBlock.content,
+				} as CanvasBlockTappedEventPayload)
+			)
+		})
+	})
+
+	describe('CanvasCarousel & CanvasCard Components', () => {
+		const mockCanvases: Canvas[] = [
+			{
+				id: 'canvas-1',
+				title: 'First Canvas',
+				blocks: [{ id: 'b1', type: 'emoji', content: '🚀' }],
+				createdAt: 1000,
+			},
+			{
+				id: 'canvas-2',
+				title: 'Second Canvas',
+				blocks: [{ id: 'b2', type: 'number', content: '7' }],
+				createdAt: 2000,
+			},
+		]
+
+		it('renders horizontal carousel with data-name="canvas-carousel" and cards with data-name="canvas-card"', () => {
+			const handleSelect = mock()
+			render(
+				<CanvasCarousel
+					canvases={mockCanvases}
+					onSelectCanvas={handleSelect}
+				/>
+			)
+
+			const carousel = document.querySelector('[data-name="canvas-carousel"]')
+			expect(carousel).not.toBeNull()
+
+			const cards = document.querySelectorAll('[data-name="canvas-card"]')
+			expect(cards.length).toBe(2)
+		})
+
+		it('triggers onSelectCanvas when a canvas card is clicked', () => {
+			const handleSelect = mock()
+			render(
+				<CanvasCarousel
+					canvases={mockCanvases}
+					onSelectCanvas={handleSelect}
+				/>
+			)
+
+			const cards = document.querySelectorAll('[data-name="canvas-card"]')
+			expect(cards.length).toBeGreaterThanOrEqual(1)
+
+			if (cards[0]) {
+				fireEvent.click(cards[0])
+				expect(handleSelect).toHaveBeenCalledWith(mockCanvases[0])
+			}
+		})
+
+		it('renders CanvasCard component with title and handles selection state', () => {
+			const handleClick = mock()
+			render(
+				<CanvasCard
+					canvas={mockCanvases[0]}
+					onClick={handleClick}
+					isSelected={true}
+				/>
+			)
+
+			const card = document.querySelector('[data-name="canvas-card"]')
+			expect(card).not.toBeNull()
+
+			if (card) {
+				fireEvent.click(card)
+				expect(handleClick).toHaveBeenCalledTimes(1)
+			}
+		})
+	})
+
+	describe('Canvas Deletion Flow & Modal', () => {
+		const existingCanvas: Canvas = {
+			id: 'canvas-to-delete',
+			title: 'Canvas To Remove',
+			blocks: [{ id: 'b1', type: 'paint', content: 'red' }],
+		}
+
+		it('renders delete-canvas-button in CanvasEditor and opens confirmation modal', () => {
+			const handleDelete = mock()
+			render(
+				<CanvasEditor
+					canvas={existingCanvas}
+					onSave={mock()}
+					onDelete={handleDelete}
+				/>
+			)
+
+			const deleteBtn = document.querySelector(
+				'[data-name="delete-canvas-button"]'
+			)
+			expect(deleteBtn).not.toBeNull()
+
+			if (deleteBtn) {
+				fireEvent.click(deleteBtn)
+			}
+
+			const confirmBtn = document.querySelector(
+				'[data-name="confirm-delete-canvas-button"]'
+			)
+			expect(confirmBtn).not.toBeNull()
+		})
+
+		it('renders CanvasDeleteConfirmationModal and triggers onConfirm, onDelete and posthog "canvas_deleted"', () => {
+			const handleConfirm = mock()
+			const handleCancel = mock()
+			render(
+				<CanvasDeleteConfirmationModal
+					isOpen={true}
+					onConfirm={handleConfirm}
+					onCancel={handleCancel}
+				/>
+			)
+
+			const confirmBtn = document.querySelector(
+				'[data-name="confirm-delete-canvas-button"]'
+			)
+			expect(confirmBtn).not.toBeNull()
+
+			if (confirmBtn) {
+				fireEvent.click(confirmBtn)
+				expect(handleConfirm).toHaveBeenCalledTimes(1)
+			}
+
+			// Verify PostHog tracking on canvas deletion
+			const handleDelete = mock()
+			render(
+				<CanvasEditor
+					canvas={existingCanvas}
+					onSave={mock()}
+					onDelete={handleDelete}
+				/>
+			)
+			const deleteBtn = document.querySelector(
+				'[data-name="delete-canvas-button"]'
+			)
+			if (deleteBtn) {
+				fireEvent.click(deleteBtn)
+			}
+			const modalConfirmBtn = document.querySelector(
+				'[data-name="confirm-delete-canvas-button"]'
+			)
+			if (modalConfirmBtn) {
+				fireEvent.click(modalConfirmBtn)
+				expect(handleDelete).toHaveBeenCalledWith(existingCanvas.id)
+				expect(mockPosthogCapture).toHaveBeenCalledWith(
+					'canvas_deleted',
+					expect.objectContaining({
+						canvasId: existingCanvas.id,
+					} as CanvasDeletedEventPayload)
+				)
+			}
+		})
+	})
+})

--- a/components/canvas.tsx
+++ b/components/canvas.tsx
@@ -1,0 +1,430 @@
+'use client'
+
+import React, { useState, useEffect, useRef } from 'react'
+import {
+	Plus,
+	Trash2,
+	Sparkles,
+	AlertTriangle,
+	FileText,
+	Activity,
+	Smile,
+	Type,
+	Hash,
+	Paintbrush,
+} from 'lucide-react'
+import type {
+	Canvas,
+	CanvasBlock,
+	CanvasBlockType,
+	CanvasBlockItemProps,
+	CanvasCardProps,
+	CanvasCarouselProps,
+	CanvasDeleteConfirmationModalProps,
+	CanvasEditorProps,
+	CanvasEmptyStateProps,
+	CanvasExamplePreviewProps,
+} from '@/lib/types/canvas'
+
+const DEFAULT_PREVIEW_BLOCKS: CanvasBlock[] = [
+	{ id: 'ex-1', type: 'emoji', content: '🎨', phrase: 'Paint' },
+	{ id: 'ex-2', type: 'letter', content: 'A', phrase: 'Letter A' },
+	{ id: 'ex-3', type: 'number', content: '1', phrase: 'Number 1' },
+	{ id: 'ex-4', type: 'activity', content: '🎵', phrase: 'Music time' },
+]
+
+export function CanvasEmptyState({
+	onCreateCanvas,
+	className = '',
+}: CanvasEmptyStateProps) {
+	return (
+		<div
+			data-name="canvas-empty-state"
+			className={`flex flex-col items-center justify-center p-8 text-center bg-white rounded-2xl border-2 border-dashed border-purple-200 shadow-sm ${className}`}
+		>
+			<div className="w-16 h-16 bg-purple-100 rounded-full flex items-center justify-center mb-4 text-purple-600">
+				<Sparkles className="w-8 h-8" />
+			</div>
+			<h2 className="text-2xl font-bold text-gray-800 mb-2">No Canvases Yet</h2>
+			<p className="text-gray-600 max-w-md mb-6">
+				Create a canvas to express yourself with interactive sound blocks, scripts, letters, numbers, and colors!
+			</p>
+
+			<div className="w-full max-w-md mb-6">
+				<CanvasExamplePreview />
+			</div>
+
+			<button
+				data-name="create-canvas-button"
+				onClick={onCreateCanvas}
+				className="px-6 py-3 bg-purple-600 text-white font-semibold rounded-xl shadow-md hover:bg-purple-700 transition flex items-center gap-2"
+			>
+				<Plus className="w-5 h-5" />
+				Create New Canvas
+			</button>
+		</div>
+	)
+}
+
+export function CanvasExamplePreview({
+	blocks = DEFAULT_PREVIEW_BLOCKS,
+	className = '',
+}: CanvasExamplePreviewProps) {
+	return (
+		<div
+			data-name="canvas-example-preview"
+			className={`p-4 bg-purple-50/60 rounded-xl border border-purple-100 ${className}`}
+		>
+			<span className="text-xs font-semibold text-purple-600 uppercase tracking-wider block mb-3 text-left">
+				Example Canvas Preview
+			</span>
+			<div className="flex flex-wrap gap-3 justify-center">
+				{blocks.map((block) => (
+					<div
+						key={block.id}
+						className="px-4 py-3 bg-white rounded-xl shadow-sm border border-purple-100 flex items-center gap-2"
+					>
+						<span className="text-2xl">{block.content}</span>
+						{block.phrase && (
+							<span className="text-xs font-medium text-gray-600">{block.phrase}</span>
+						)}
+					</div>
+				))}
+			</div>
+		</div>
+	)
+}
+
+export function CanvasCarousel({
+	canvases,
+	onSelectCanvas,
+	selectedCanvasId,
+	className = '',
+}: CanvasCarouselProps) {
+	return (
+		<div
+			data-name="canvas-carousel"
+			className={`flex gap-4 overflow-x-auto pb-4 pt-2 px-1 scrollbar-thin ${className}`}
+		>
+			{canvases.map((canvas) => (
+				<CanvasCard
+					key={canvas.id}
+					canvas={canvas}
+					isSelected={canvas.id === selectedCanvasId}
+					onClick={() => onSelectCanvas(canvas)}
+				/>
+			))}
+		</div>
+	)
+}
+
+export function CanvasCard({
+	canvas,
+	onClick,
+	isSelected,
+	className = '',
+}: CanvasCardProps) {
+	return (
+		<div
+			data-name="canvas-card"
+			onClick={onClick}
+			className={`min-w-[200px] max-w-[240px] p-4 rounded-xl cursor-pointer transition-all border ${
+				isSelected
+					? 'bg-purple-50 border-purple-600 shadow-md ring-2 ring-purple-600/20'
+					: 'bg-white border-gray-200 hover:border-purple-300 hover:shadow-sm'
+			} ${className}`}
+		>
+			<h3 className="font-bold text-gray-900 truncate mb-1">
+				{canvas.title || 'Untitled Canvas'}
+			</h3>
+			<p className="text-xs text-gray-500 mb-3">
+				{canvas.blocks.length} {canvas.blocks.length === 1 ? 'block' : 'blocks'}
+			</p>
+			<div className="flex gap-1 overflow-hidden">
+				{canvas.blocks.slice(0, 4).map((b, i) => (
+					<span
+						key={b.id || i}
+						className="text-sm px-1.5 py-0.5 bg-gray-100 rounded border border-gray-200"
+					>
+						{b.content || b.type}
+					</span>
+				))}
+				{canvas.blocks.length > 4 && (
+					<span className="text-xs px-1.5 py-0.5 bg-gray-100 rounded text-gray-500">
+						+{canvas.blocks.length - 4}
+					</span>
+				)}
+			</div>
+		</div>
+	)
+}
+
+export function CanvasBlockItem({
+	block,
+	onTap,
+	isAnimating = false,
+	className = '',
+}: CanvasBlockItemProps) {
+	const [tappedAnimation, setTappedAnimation] = useState(false)
+
+	const handleTap = () => {
+		setTappedAnimation(true)
+		setTimeout(() => setTappedAnimation(false), 600)
+
+		// Trigger PostHog event
+		if (typeof window !== 'undefined' && window.posthog) {
+			window.posthog.capture('canvas_block_tapped', {
+				blockType: block.type,
+				content: block.content,
+			})
+		}
+
+		// Trigger speech synthesis
+		if (typeof window !== 'undefined' && 'speechSynthesis' in window && window.speechSynthesis) {
+			const textToSpeak = block.phrase || block.label || block.content
+			if (textToSpeak) {
+				const utterance = new SpeechSynthesisUtterance(textToSpeak)
+				window.speechSynthesis.speak(utterance)
+			}
+		}
+
+		onTap?.(block)
+	}
+
+	const showBounce = isAnimating || tappedAnimation
+
+	return (
+		<div
+			data-name={`canvas-block-${block.type}`}
+			onClick={handleTap}
+			className={`p-4 rounded-xl bg-white border-2 border-purple-100 shadow-sm hover:shadow-md cursor-pointer transition-all flex flex-col items-center justify-center min-w-[100px] min-h-[100px] select-none ${
+				showBounce ? 'animate-seed-bounce border-purple-400 ring-2 ring-purple-300' : ''
+			} ${className}`}
+		>
+			<span className="text-3xl mb-1">{block.content}</span>
+			{block.label && (
+				<span className="text-xs font-semibold text-gray-700">{block.label}</span>
+			)}
+			{block.phrase && (
+				<span className="text-[10px] text-gray-500 mt-0.5">{block.phrase}</span>
+			)}
+		</div>
+	)
+}
+
+export function CanvasDeleteConfirmationModal({
+	isOpen,
+	onConfirm,
+	onCancel,
+}: CanvasDeleteConfirmationModalProps) {
+	const [dismissed, setDismissed] = useState(false)
+
+	useEffect(() => {
+		if (isOpen) {
+			setDismissed(false)
+		}
+	}, [isOpen])
+
+	if (!isOpen || dismissed) return null
+
+	const handleConfirm = () => {
+		setDismissed(true)
+		onConfirm()
+	}
+
+	const handleCancel = () => {
+		setDismissed(true)
+		onCancel()
+	}
+
+	return (
+		<div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+			<div className="bg-white rounded-2xl max-w-md w-full p-6 shadow-xl border border-gray-100">
+				<div className="flex items-center gap-3 mb-4 text-red-600">
+					<div className="w-10 h-10 rounded-full bg-red-100 flex items-center justify-center">
+						<AlertTriangle className="w-5 h-5" />
+					</div>
+					<h3 className="text-xl font-bold text-gray-900">Delete Canvas?</h3>
+				</div>
+				<p className="text-gray-600 mb-6">
+					Are you sure you want to delete this canvas? This action cannot be undone.
+				</p>
+				<div className="flex justify-end gap-3">
+					<button
+						data-name="cancel-delete-canvas-button"
+						onClick={handleCancel}
+						className="px-4 py-2 text-gray-700 font-medium hover:bg-gray-100 rounded-lg transition"
+					>
+						Cancel
+					</button>
+					<button
+						data-name="confirm-delete-canvas-button"
+						onClick={handleConfirm}
+						className="px-4 py-2 bg-red-600 text-white font-medium hover:bg-red-700 rounded-lg shadow-sm transition"
+					>
+						Delete
+					</button>
+				</div>
+			</div>
+		</div>
+	)
+}
+
+const DEFAULT_BLOCK_TEMPLATES: Record<
+	CanvasBlockType,
+	{ content: string; label: string; phrase?: string; seed?: string }
+> = {
+	script: { content: '📜', label: 'Script Block', phrase: 'Reading script', seed: 'script-seed' },
+	activity: { content: '🎯', label: 'Activity Block', phrase: 'Doing activity', seed: 'activity-seed' },
+	emoji: { content: '⭐', label: 'Star', phrase: 'Shining star', seed: 'emoji-seed' },
+	letter: { content: 'A', label: 'Letter A', phrase: 'Letter A', seed: 'letter-seed' },
+	number: { content: '1', label: 'Number 1', phrase: 'Number 1', seed: 'number-seed' },
+	paint: { content: '🎨', label: 'Paint Block', phrase: 'Painting colors', seed: 'paint-seed' },
+}
+
+const BLOCK_TYPE_CONFIG: { type: CanvasBlockType; label: string; icon: React.ComponentType<{ className?: string }> }[] = [
+	{ type: 'script', label: 'Script', icon: FileText },
+	{ type: 'activity', label: 'Activity', icon: Activity },
+	{ type: 'emoji', label: 'Emoji', icon: Smile },
+	{ type: 'letter', label: 'Letter', icon: Type },
+	{ type: 'number', label: 'Number', icon: Hash },
+	{ type: 'paint', label: 'Paint', icon: Paintbrush },
+]
+
+export function CanvasEditor({
+	canvas,
+	onSave,
+	onDelete,
+	onBlockTap,
+	className = '',
+}: CanvasEditorProps) {
+	const titleInputRef = useRef<HTMLInputElement>(null)
+	const [blocks, setBlocks] = useState<CanvasBlock[]>(canvas?.blocks || [])
+	const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false)
+
+	useEffect(() => {
+		if (canvas && titleInputRef.current) {
+			titleInputRef.current.value = canvas.title || ''
+			setBlocks(canvas.blocks || [])
+		}
+	}, [canvas])
+
+	const addBlock = (type: CanvasBlockType) => {
+		const template = DEFAULT_BLOCK_TEMPLATES[type]
+		const newBlock: CanvasBlock = {
+			id: `block-${Date.now()}-${Math.random().toString(36).substring(2, 6)}`,
+			type,
+			content: template.content,
+			label: template.label,
+			phrase: template.phrase,
+			seed: template.seed,
+		}
+		setBlocks((prev) => [...prev, newBlock])
+	}
+
+	const handleSave = () => {
+		const finalTitle = titleInputRef.current?.value || ''
+
+		onSave({ title: finalTitle, blocks })
+
+		if (typeof window !== 'undefined' && window.posthog) {
+			window.posthog.capture('canvas_created', {
+				title: finalTitle,
+				blockTypes: blocks.map((b) => b.type),
+			})
+		}
+	}
+
+	const handleConfirmDelete = () => {
+		if (canvas?.id && onDelete) {
+			onDelete(canvas.id)
+			if (typeof window !== 'undefined' && window.posthog) {
+				window.posthog.capture('canvas_deleted', {
+					canvasId: canvas.id,
+				})
+			}
+		}
+		setIsDeleteModalOpen(false)
+	}
+
+	return (
+		<div className={`bg-white rounded-2xl border border-gray-200 p-6 shadow-sm ${className}`}>
+			<div className="flex flex-col sm:flex-row gap-4 justify-between items-start sm:items-center mb-6">
+				<input
+					ref={titleInputRef}
+					data-name="canvas-title-input"
+					type="text"
+					defaultValue={canvas?.title || ''}
+					placeholder="Canvas Title (e.g., My Creative Space)"
+					className="w-full sm:w-80 px-4 py-2 rounded-xl border border-gray-300 focus:outline-none focus:ring-2 focus:ring-purple-500 font-semibold text-lg"
+				/>
+
+				<div className="flex items-center gap-2">
+					{(canvas || onDelete) && (
+						<button
+							data-name="delete-canvas-button"
+							onClick={() => setIsDeleteModalOpen(true)}
+							className="px-4 py-2 text-red-600 border border-red-200 hover:bg-red-50 font-medium rounded-xl transition flex items-center gap-2"
+						>
+							<Trash2 className="w-4 h-4" />
+							Delete
+						</button>
+					)}
+					<button
+						data-name="save-canvas-button"
+						onClick={handleSave}
+						className="px-6 py-2 bg-purple-600 hover:bg-purple-700 text-white font-semibold rounded-xl shadow transition"
+					>
+						Save Canvas
+					</button>
+				</div>
+			</div>
+
+			<div className="mb-6">
+				<label className="block text-xs font-semibold text-gray-500 uppercase tracking-wider mb-2">
+					Add Blocks
+				</label>
+				<div className="flex flex-wrap gap-2">
+					{BLOCK_TYPE_CONFIG.map(({ type, label, icon: Icon }) => (
+						<button
+							key={type}
+							data-name={`add-block-${type}`}
+							onClick={() => addBlock(type)}
+							className="px-3 py-2 bg-purple-50 hover:bg-purple-100 text-purple-700 text-sm font-medium rounded-lg border border-purple-200 flex items-center gap-1.5 transition"
+						>
+							<Icon className="w-4 h-4" />
+							+ {label}
+						</button>
+					))}
+				</div>
+			</div>
+
+			<div>
+				<label className="block text-xs font-semibold text-gray-500 uppercase tracking-wider mb-3">
+					Canvas Workspace
+				</label>
+				{blocks.length === 0 ? (
+					<div className="p-8 text-center text-gray-400 bg-gray-50 rounded-xl border border-dashed border-gray-200">
+						No blocks added yet. Click an add-block button above to populate your canvas!
+					</div>
+				) : (
+					<div className="flex flex-wrap gap-4 p-4 bg-gray-50 rounded-xl border border-gray-200 min-h-[160px]">
+						{blocks.map((block) => (
+							<CanvasBlockItem
+								key={block.id}
+								block={block}
+								onTap={onBlockTap}
+							/>
+						))}
+					</div>
+				)}
+			</div>
+
+			<CanvasDeleteConfirmationModal
+				isOpen={isDeleteModalOpen}
+				onConfirm={handleConfirmDelete}
+				onCancel={() => setIsDeleteModalOpen(false)}
+			/>
+		</div>
+	)
+}

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -10,6 +10,7 @@
 
 import type * as auth from "../auth.js";
 import type * as boards from "../boards.js";
+import type * as canvas from "../canvas.js";
 import type * as http from "../http.js";
 import type * as learners from "../learners.js";
 import type * as resendOtp from "../resendOtp.js";
@@ -26,6 +27,7 @@ import type {
 declare const fullApi: ApiFromModules<{
   auth: typeof auth;
   boards: typeof boards;
+  canvas: typeof canvas;
   http: typeof http;
   learners: typeof learners;
   resendOtp: typeof resendOtp;

--- a/convex/canvas.ts
+++ b/convex/canvas.ts
@@ -1,0 +1,114 @@
+import { v } from 'convex/values'
+import { mutation, query } from './_generated/server'
+
+const blockValidator = v.object({
+	id: v.string(),
+	type: v.union(
+		v.literal('script'),
+		v.literal('activity'),
+		v.literal('emoji'),
+		v.literal('letter'),
+		v.literal('number'),
+		v.literal('paint'),
+	),
+	content: v.string(),
+	label: v.optional(v.string()),
+	phrase: v.optional(v.string()),
+	seed: v.optional(v.string()),
+})
+
+const canvasValidator = v.object({
+	_id: v.id('canvases'),
+	_creationTime: v.number(),
+	learnerId: v.optional(v.id('learners')),
+	title: v.string(),
+	blocks: v.array(blockValidator),
+	createdAt: v.optional(v.number()),
+	updatedAt: v.optional(v.number()),
+})
+
+export const getCanvases = query({
+	args: { learnerId: v.optional(v.id('learners')) },
+	returns: v.array(canvasValidator),
+	handler: async (ctx, args) => {
+		if (!args.learnerId) return []
+		return await ctx.db
+			.query('canvases')
+			.withIndex('by_learner', q => q.eq('learnerId', args.learnerId))
+			.order('desc')
+			.collect()
+	},
+})
+
+export const getCanvasesByPassphrase = query({
+	args: { passphrase: v.string() },
+	returns: v.array(canvasValidator),
+	handler: async (ctx, args) => {
+		const learner = await ctx.db
+			.query('learners')
+			.withIndex('by_passphrase', q => q.eq('passphrase', args.passphrase))
+			.unique()
+		if (!learner) return []
+		return await ctx.db
+			.query('canvases')
+			.withIndex('by_learner', q => q.eq('learnerId', learner._id))
+			.order('desc')
+			.collect()
+	},
+})
+
+export const getCanvas = query({
+	args: { id: v.id('canvases') },
+	returns: v.union(canvasValidator, v.null()),
+	handler: async (ctx, args) => {
+		return await ctx.db.get(args.id)
+	},
+})
+
+export const createCanvas = mutation({
+	args: {
+		learnerId: v.optional(v.id('learners')),
+		title: v.string(),
+		blocks: v.array(blockValidator),
+	},
+	returns: v.id('canvases'),
+	handler: async (ctx, args) => {
+		const now = Date.now()
+		return await ctx.db.insert('canvases', {
+			learnerId: args.learnerId,
+			title: args.title,
+			blocks: args.blocks,
+			createdAt: now,
+			updatedAt: now,
+		})
+	},
+})
+
+export const updateCanvas = mutation({
+	args: {
+		canvasId: v.id('canvases'),
+		title: v.optional(v.string()),
+		blocks: v.optional(v.array(blockValidator)),
+	},
+	returns: v.null(),
+	handler: async (ctx, args) => {
+		const updates: {
+			title?: string
+			blocks?: typeof args.blocks
+			updatedAt: number
+		} = { updatedAt: Date.now() }
+		if (args.title !== undefined) updates.title = args.title
+		if (args.blocks !== undefined) updates.blocks = args.blocks
+		await ctx.db.patch(args.canvasId, updates)
+		return null
+	},
+})
+
+export const deleteCanvas = mutation({
+	args: { canvasId: v.id('canvases') },
+	returns: v.null(),
+	handler: async (ctx, args) => {
+		await ctx.db.delete(args.canvasId)
+		return null
+	},
+})

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -65,4 +65,27 @@ export default defineSchema({
 	})
 		.index('by_learner', ['learnerId'])
 		.index('by_learner_active', ['learnerId', 'isActive']),
+	canvases: defineTable({
+		learnerId: v.optional(v.id('learners')),
+		title: v.string(),
+		blocks: v.array(
+			v.object({
+				id: v.string(),
+				type: v.union(
+					v.literal('script'),
+					v.literal('activity'),
+					v.literal('emoji'),
+					v.literal('letter'),
+					v.literal('number'),
+					v.literal('paint'),
+				),
+				content: v.string(),
+				label: v.optional(v.string()),
+				phrase: v.optional(v.string()),
+				seed: v.optional(v.string()),
+			}),
+		),
+		createdAt: v.optional(v.number()),
+		updatedAt: v.optional(v.number()),
+	}).index('by_learner', ['learnerId']),
 })

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -1,5 +1,10 @@
 import { defineConfig } from 'cypress'
 import { execSync } from 'child_process'
+import fs from 'fs'
+
+const envFlag = fs.existsSync('.env.test.local')
+	? '--env-file .env.test.local '
+	: ''
 
 export default defineConfig({
 	e2e: {
@@ -8,7 +13,7 @@ export default defineConfig({
 			on('task', {
 				resetCypressUsers() {
 					execSync(
-						'bunx convex run --env-file .env.test.local internal.testing.resetCypressUsers',
+						`bunx convex run ${envFlag}internal.testing.resetCypressUsers`,
 						{
 							stdio: 'inherit',
 						},
@@ -17,7 +22,7 @@ export default defineConfig({
 				},
 				clearVerificationCodes() {
 					execSync(
-						'bunx convex run --env-file .env.test.local internal.testing.clearVerificationCodes',
+						`bunx convex run ${envFlag}internal.testing.clearVerificationCodes`,
 						{
 							stdio: 'inherit',
 						},
@@ -35,7 +40,7 @@ export default defineConfig({
 				}) {
 					const args = JSON.stringify({ email, name, bio })
 					const result = execSync(
-						`bunx convex run --env-file .env.test.local internal.testing.createTestLearner '${args}'`,
+						`bunx convex run ${envFlag}internal.testing.createTestLearner '${args}'`,
 						{ encoding: 'utf-8' },
 					)
 					const raw = result.trim()

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -7,15 +7,21 @@ export default defineConfig({
 		setupNodeEvents(on, config) {
 			on('task', {
 				resetCypressUsers() {
-					execSync('bun convex run internal.testing.resetCypressUsers', {
-						stdio: 'inherit',
-					})
+					execSync(
+						'bunx convex run --env-file .env.test.local internal.testing.resetCypressUsers',
+						{
+							stdio: 'inherit',
+						},
+					)
 					return null
 				},
 				clearVerificationCodes() {
-					execSync('bun convex run internal.testing.clearVerificationCodes', {
-						stdio: 'inherit',
-					})
+					execSync(
+						'bunx convex run --env-file .env.test.local internal.testing.clearVerificationCodes',
+						{
+							stdio: 'inherit',
+						},
+					)
 					return null
 				},
 				createTestLearner({
@@ -29,10 +35,19 @@ export default defineConfig({
 				}) {
 					const args = JSON.stringify({ email, name, bio })
 					const result = execSync(
-						`bun convex run internal.testing.createTestLearner '${args}'`,
+						`bunx convex run --env-file .env.test.local internal.testing.createTestLearner '${args}'`,
 						{ encoding: 'utf-8' },
 					)
-					return result.trim().replace(/^"|"$/g, '')
+					const raw = result.trim()
+					try {
+						return JSON.parse(raw)
+					} catch {
+						try {
+							return Function('"use strict";return (' + raw + ')')()
+						} catch {
+							return raw.replace(/^"|"$/g, '')
+						}
+					}
 				},
 			})
 		},

--- a/cypress/e2e/canvas.cy.ts
+++ b/cypress/e2e/canvas.cy.ts
@@ -1,0 +1,107 @@
+describe('Learner Canvas', () => {
+	const testEmail = 'cypress-canvas@banerry.app'
+	let passphrase = ''
+
+	before(() => {
+		cy.signIn(testEmail)
+		cy.task('createTestLearner', {
+			email: testEmail,
+			name: `Canvas Learner ${Date.now()}`,
+		}).then((res: any) => {
+			let data: any
+			if (typeof res === 'string') {
+				try {
+					data = JSON.parse(res)
+				} catch {
+					try {
+						data = Function('"use strict";return (' + res + ')')()
+					} catch {
+						data = { passphrase: res }
+					}
+				}
+			} else {
+				data = res
+			}
+			passphrase = data?.passphrase || (typeof res === 'string' ? res : '')
+		})
+	})
+
+	beforeEach(() => {
+		cy.on('uncaught:exception', error => {
+			if (error.message.includes('Unauthenticated')) return false
+		})
+		cy.clearAllCookies()
+		cy.clearAllLocalStorage()
+		cy.clearAllSessionStorage()
+	})
+
+	it('Scenario: No existing canvases - prompts learner to create canvas with visual example', () => {
+		cy.visit(`/learner/${passphrase}/canvas`)
+		cy.getByName('canvas-empty-state', { timeout: 10000 }).should('be.visible')
+		cy.getByName('canvas-example-preview', { timeout: 10000 }).should('be.visible')
+		cy.getByName('create-canvas-button', { timeout: 10000 }).should('be.visible')
+	})
+
+	it('Scenario Outline: Create canvas and place blocks (script, activity, emoji, letter, number, paint) & track PostHog event', () => {
+		cy.visit(`/learner/${passphrase}/canvas`, {
+			onBeforeLoad(win) {
+				win.posthog = {
+					capture: cy.stub().as('posthogCapture'),
+				} as any
+			},
+		})
+
+		cy.getByName('create-canvas-button', { timeout: 10000 }).click()
+		cy.getByName('canvas-title-input', { timeout: 10000 }).type('My Creative Space')
+
+		const blocks = ['script', 'activity', 'emoji', 'letter', 'number', 'paint']
+		blocks.forEach(blockType => {
+			cy.getByName(`add-block-${blockType}`).click()
+			cy.getByName(`canvas-block-${blockType}`, { timeout: 10000 }).should('be.visible')
+		})
+
+		cy.getByName('save-canvas-button').click()
+		cy.contains('My Creative Space', { timeout: 10000 }).should('be.visible')
+
+		cy.get('@posthogCapture').should('have.been.calledWith', 'canvas_created', Cypress.sinon.match.object)
+	})
+
+	it('Scenario Outline: View canvas, tap on block to say out loud and animate & track PostHog event', () => {
+		cy.visit(`/learner/${passphrase}/canvas`, {
+			onBeforeLoad(win) {
+				win.posthog = {
+					capture: cy.stub().as('posthogCapture'),
+				} as any
+			},
+		})
+
+		cy.getByName('canvas-card', { timeout: 10000 }).first().click()
+		cy.getByName('canvas-block-emoji', { timeout: 10000 }).first().click()
+		cy.getByName('canvas-block-emoji').first().should('have.class', 'animate-seed-bounce')
+
+		cy.get('@posthogCapture').should('have.been.calledWith', 'canvas_block_tapped', Cypress.sinon.match.object)
+	})
+
+	it('Scenario: Existing canvases - displays horizontal carousel of existing canvases', () => {
+		cy.visit(`/learner/${passphrase}/canvas`)
+		cy.getByName('canvas-carousel', { timeout: 10000 }).should('be.visible')
+		cy.getByName('canvas-card', { timeout: 10000 }).should('have.length.at.least', 1)
+	})
+
+	it('Scenario: Remove canvas - deletes canvas after confirmation & tracks PostHog event', () => {
+		cy.visit(`/learner/${passphrase}/canvas`, {
+			onBeforeLoad(win) {
+				win.posthog = {
+					capture: cy.stub().as('posthogCapture'),
+				} as any
+			},
+		})
+
+		cy.getByName('canvas-card', { timeout: 10000 }).first().click()
+		cy.getByName('delete-canvas-button', { timeout: 10000 }).click()
+		cy.getByName('confirm-delete-canvas-button', { timeout: 10000 }).click()
+
+		cy.get('@posthogCapture').should('have.been.calledWith', 'canvas_deleted', Cypress.sinon.match.object)
+		cy.getByName('canvas-card', { timeout: 10000 }).should('not.exist')
+	})
+})

--- a/lib/types/canvas.ts
+++ b/lib/types/canvas.ts
@@ -1,0 +1,132 @@
+/**
+ * Canvas Feature Types & Component Contracts
+ * Derived from feature spec: Banerry Canvas.md
+ * and E2E requirements in cypress/e2e/canvas.cy.ts
+ */
+
+/**
+ * Types of blocks that can be placed on a Canvas.
+ */
+export type CanvasBlockType =
+	| 'script'
+	| 'activity'
+	| 'emoji'
+	| 'letter'
+	| 'number'
+	| 'paint'
+
+/**
+ * Interface representing an individual block on a Canvas.
+ */
+export interface CanvasBlock {
+	id: string
+	type: CanvasBlockType
+	content: string
+	label?: string
+	phrase?: string
+	seed?: string
+}
+
+/**
+ * Interface representing a Canvas document.
+ */
+export interface Canvas {
+	id: string
+	title: string
+	learnerId?: string
+	blocks: CanvasBlock[]
+	createdAt?: number
+	updatedAt?: number
+}
+
+/**
+ * Component Props Contract: CanvasEmptyState
+ * Rendered when a learner has no existing canvases.
+ * Contains canvas-empty-state, canvas-example-preview, create-canvas-button.
+ */
+export interface CanvasEmptyStateProps {
+	onCreateCanvas: () => void
+	className?: string
+}
+
+/**
+ * Component Props Contract: CanvasExamplePreview
+ * Simple visual example of what a canvas might look like.
+ */
+export interface CanvasExamplePreviewProps {
+	blocks?: CanvasBlock[]
+	className?: string
+}
+
+/**
+ * Component Props Contract: CanvasCarousel
+ * Horizontal carousel displaying existing canvases.
+ */
+export interface CanvasCarouselProps {
+	canvases: Canvas[]
+	onSelectCanvas: (canvas: Canvas) => void
+	selectedCanvasId?: string
+	className?: string
+}
+
+/**
+ * Component Props Contract: CanvasCard
+ * Individual canvas card displayed within the carousel or list.
+ */
+export interface CanvasCardProps {
+	canvas: Canvas
+	onClick: () => void
+	isSelected?: boolean
+	className?: string
+}
+
+/**
+ * Component Props Contract: CanvasBlockItem
+ * Individual block item on a canvas. Tapping it triggers speech output and animation.
+ */
+export interface CanvasBlockItemProps {
+	block: CanvasBlock
+	onTap?: (block: CanvasBlock) => void
+	isAnimating?: boolean
+	className?: string
+}
+
+/**
+ * Component Props Contract: CanvasEditor / CanvasView
+ * Interface for creating/editing/viewing a canvas.
+ * Manages canvas title input, adding blocks, saving, deleting, and block tap actions.
+ */
+export interface CanvasEditorProps {
+	canvas?: Canvas | null
+	onSave: (data: { title: string; blocks: CanvasBlock[] }) => void
+	onDelete?: (canvasId: string) => void
+	onBlockTap?: (block: CanvasBlock) => void
+	className?: string
+}
+
+/**
+ * Component Props Contract: CanvasDeleteConfirmationModal
+ * Dialog/Modal for confirming permanent deletion of a canvas.
+ */
+export interface CanvasDeleteConfirmationModalProps {
+	isOpen: boolean
+	onConfirm: () => void
+	onCancel: () => void
+}
+
+/**
+ * PostHog Analytics Event Payloads for Canvas
+ */
+export interface CanvasCreatedEventPayload {
+	title: string
+	blockTypes: CanvasBlockType[]
+}
+
+export interface CanvasBlockTappedEventPayload {
+	blockType: CanvasBlockType
+	content: string
+}
+
+export interface CanvasDeletedEventPayload {
+	canvasId?: string
+}

--- a/package.json
+++ b/package.json
@@ -90,6 +90,8 @@
 		"zod": "^3.24.1"
 	},
 	"devDependencies": {
+		"@testing-library/dom": "^10.4.1",
+		"@testing-library/react": "^16.3.2",
 		"@types/bun": "^1.3.8",
 		"@types/canvas-confetti": "^1.6.4",
 		"@types/events": "^3.0.3",
@@ -102,6 +104,7 @@
 		"dotenv": "^16.4.7",
 		"eslint": "^9.33.0",
 		"eslint-config-next": "15.5.12",
+		"happy-dom": "^20.11.1",
 		"husky": "^9.1.7",
 		"msw": "^2.12.9",
 		"npm-run-all": "^4.1.5",


### PR DESCRIPTION
## Summary
Implements the **Banerry Canvas** feature () according to feature specification `/home/openclaw/obsidian/reality-sculptor/Banerry Canvas.md`.

## Key Changes
- **Convex Schema & Backend**: Added `canvases` table indexed by `learnerId` in [`convex/schema.ts`](file:///home/openclaw/code/homostellaris/banerry/convex/schema.ts) and queries/mutations in [`convex/canvas.ts`](file:///home/openclaw/code/homostellaris/banerry/convex/canvas.ts).
- **TypeScript & Contracts**: Defined full canvas component interfaces and block schemas in [`lib/types/canvas.ts`](file:///home/openclaw/code/homostellaris/banerry/lib/types/canvas.ts).
- **UI Components**: Built `CanvasEmptyState`, `CanvasExamplePreview`, `CanvasCarousel`, `CanvasCard`, `CanvasBlockItem`, `CanvasEditor`, and `CanvasDeleteConfirmationModal` in [`components/canvas.tsx`](file:///home/openclaw/code/homostellaris/banerry/components/canvas.tsx).
- **Speech Synthesis & Micro-Animations**: Added SpeechSynthesis text-to-speech sound output and `animate-seed-bounce` CSS animation on block tap.
- **PostHog Analytics**: Instrumented event tracking for `canvas_created`, `canvas_block_tapped`, and `canvas_deleted`.
- **Learner Route**: Created [`app/learner/[passphrase]/canvas/page.tsx`](file:///home/openclaw/code/homostellaris/banerry/app/learner/[passphrase]/canvas/page.tsx) with non-blocking real-time Convex synchronization.
- **Testing**:
  - 13 React Testing Library / Happy-DOM unit tests in [`components/canvas.test.tsx`](file:///home/openclaw/code/homostellaris/banerry/components/canvas.test.tsx) passing 100%.
  - 5 Cypress E2E integration tests in [`cypress/e2e/canvas.cy.ts`](file:///home/openclaw/code/homostellaris/banerry/cypress/e2e/canvas.cy.ts) passing 100%.
  - `bun typecheck`: 0 errors.